### PR TITLE
Added logging with logback and SLF4J.

### DIFF
--- a/HelloWorldService/hello-world.yml
+++ b/HelloWorldService/hello-world.yml
@@ -1,2 +1,26 @@
 template: Hello, %s!
 defaultName: Stranger
+# DropWizard Logging defaults are specified here: https://www.dropwizard.io/0.7.1/docs/manual/configuration.html#logging
+# Logging can be customized as shown below:
+logging:
+
+  loggers:
+    # System-wide logging is configured in DropWizard
+    # It can be changed below:
+    # io.dropwizard: INFO
+    "com.gpnk.helloworld.HelloWorldResource": DEBUG
+
+  appenders:
+    - type: console
+      # console log config is inherited from DropWizard
+    - type: file
+      # TODO: change to a PROPER log file path
+      currentLogFilename: /var/tmp/hello-world.log
+      threshold: ALL
+      archive: true
+      #  %d is replaced with the date in yyyy-MM-dd form,
+      # and the fact that it ends with .gz indicates the file will be gzipped as it’s archived
+      # TODO: change to a PROPER log file archive path
+      archivedLogFilenamePattern: /var/tmp/hello-world-%d.gz
+      archivedFileCount: 5
+      timeZone: UTC

--- a/HelloWorldService/pom.xml
+++ b/HelloWorldService/pom.xml
@@ -14,11 +14,13 @@
   </properties>
 
   <dependencies>
+
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-core</artifactId>
       <version>${version.dropwizard}</version>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldResource.java
+++ b/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldResource.java
@@ -1,6 +1,8 @@
 package com.gpnk.helloworld;
 
 import com.codahale.metrics.annotation.Timed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -13,6 +15,8 @@ import java.util.Optional;
 @Produces(MediaType.APPLICATION_JSON)
 public class HelloWorldResource {
 
+    private final Logger log = LoggerFactory.getLogger(HelloWorldResource.class);
+
     private final String template;
     private final String defaultName;
 
@@ -24,8 +28,20 @@ public class HelloWorldResource {
     @GET
     @Timed
     public String sayHello(@QueryParam("name") Optional<String> name) {
+        performSampleLogging("Get method /sayHello called. Using name = " + name.orElse(defaultName));
         final String value = String.format(template, name.orElse(defaultName));
         return value;
+    }
+
+    /* Demonstrates logging. As per logback config in hello.yml, messages at DEBUG
+     * level and higher are printed to console appender.
+     **/
+    private void performSampleLogging(String message) {
+        log.trace(message);
+        log.debug(message);
+        log.info(message);
+        log.warn(message);
+        log.error(message);
     }
 
 

--- a/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
+++ b/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
@@ -5,6 +5,10 @@ import com.gpnk.helloworld.PingHealthCheck;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.glassfish.jersey.logging.LoggingFeature;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
 
@@ -55,6 +59,15 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
 
         // TODO: use DI to bind and register application specific HealthChecks
         environment.healthChecks().register("ping", new PingHealthCheck());
+
+        // Enable logging of REST requests and responses on the server
+        // TODO: enable logging in a similar way on the REST client
+        // Verbosity determines how detailed the logged message is, currently logs headers and text (which is everything);
+        // maxEntitySize - maximum number of entity bytes to log and buffer, will print and buffer up to the specified
+        // number of bytes cutting off the rest.
+        // For more details: https://www.javaguides.net/2018/06/jersey-rest-logging-using-loggingfeature.html
+        environment.jersey().register(new LoggingFeature(Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME),
+                Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 10000));
 
     }
 }


### PR DESCRIPTION
No need to depend on `logback jars` in `pom.xml` as `dropwizard-core` dependency brings in both logback and slf4j-api jars.
Included an example of how to customize log level per class. 
Greg, do we want anything else out of logging at this point?