### PR TITLE
Added CheckStyle.

### DIFF
--- a/GoogleWagonTest/pom.xml
+++ b/GoogleWagonTest/pom.xml
@@ -8,6 +8,12 @@
   <name>GoogleWagonTest</name>
   <url>http://maven.apache.org</url>
 
+  <parent>
+    <groupId>com.gpnk</groupId>
+    <artifactId>gpnk-monkey-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -23,6 +29,12 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+    </plugins>
     <extensions>
       <extension>
         <groupId>com.gkatzioura.maven.cloud</groupId>

--- a/GoogleWagonTest/src/main/java/com/test/apps/App.java
+++ b/GoogleWagonTest/src/main/java/com/test/apps/App.java
@@ -4,10 +4,19 @@ package com.test.apps;
  * Hello world!
  *
  */
-public class App 
-{
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+public class App {
+
+    /**
+     * To satisfy Checkstyle's HideUtilityClassConstructor.
+     */
+    protected App() {
+    }
+
+    /**
+     * Hello World method.
+     * @param args - args
+     */
+    public static void main(final String[] args) {
+        System.out.println("Hello World!");
     }
 }

--- a/HelloWorldService/pom.xml
+++ b/HelloWorldService/pom.xml
@@ -7,6 +7,12 @@
   <version>1.0-SNAPSHOT</version>
   <name>HelloWorldService</name>
 
+  <parent>
+    <groupId>com.gpnk</groupId>
+    <artifactId>gpnk-monkey-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -24,6 +30,12 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+    </plugins>
     <extensions>
       <extension>
         <groupId>com.gkatzioura.maven.cloud</groupId>

--- a/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldResource.java
+++ b/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldResource.java
@@ -11,6 +11,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.Optional;
 
+/**
+ * Our sample Resource.
+ */
 @Path("/hello-world")
 @Produces(MediaType.APPLICATION_JSON)
 public class HelloWorldResource {
@@ -20,23 +23,35 @@ public class HelloWorldResource {
     private final String template;
     private final String defaultName;
 
-    public HelloWorldResource(String template, String defaultName) {
+    /**
+     * Main constructor.
+     * @param template - Response template.
+     * @param defaultName - default name to use.
+     */
+    public HelloWorldResource(final String template, final String defaultName) {
         this.template = template;
         this.defaultName = defaultName;
     }
 
+    /**
+     * Sample GET method.
+     * @param name - Says "Hello, Name", defaults to Stranger
+     * @return - String "Hello, Name"
+     */
     @GET
     @Timed
-    public String sayHello(@QueryParam("name") Optional<String> name) {
+    public String sayHello(@QueryParam("name") final Optional<String> name) {
         performSampleLogging("Get method /sayHello called. Using name = " + name.orElse(defaultName));
         final String value = String.format(template, name.orElse(defaultName));
         return value;
     }
 
-    /* Demonstrates logging. As per logback config in hello.yml, messages at DEBUG
+    /**
+     * Demonstrates logging. As per logback config in hello.yml, messages at DEBUG
      * level and higher are printed to console appender.
-     **/
-    private void performSampleLogging(String message) {
+     * @param message - message to print to logs.
+     */
+    private void performSampleLogging(final String message) {
         log.trace(message);
         log.debug(message);
         log.info(message);

--- a/HelloWorldService/src/main/java/com/gpnk/helloworld/PingHealthCheck.java
+++ b/HelloWorldService/src/main/java/com/gpnk/helloworld/PingHealthCheck.java
@@ -2,8 +2,16 @@ package com.gpnk.helloworld;
 
 import com.codahale.metrics.health.HealthCheck;
 
+/**
+ * Application's HealthCheck.
+ */
 public class PingHealthCheck extends HealthCheck {
 
+    /**
+     * Main healthcheck.
+     * @return Result of the health check.
+     * @throws Exception Propagates errors up.
+     */
     @Override
     protected Result check() throws Exception {
         return Result.healthy();

--- a/HelloWorldService/src/main/java/com/gpnk/models/HelloWorldConfiguration.java
+++ b/HelloWorldService/src/main/java/com/gpnk/models/HelloWorldConfiguration.java
@@ -1,4 +1,4 @@
-package com.gpnk.server;
+package com.gpnk.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;

--- a/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
+++ b/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
@@ -2,14 +2,17 @@ package com.gpnk.server;
 
 import com.gpnk.helloworld.HelloWorldResource;
 import com.gpnk.helloworld.PingHealthCheck;
+import com.gpnk.models.HelloWorldConfiguration;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.logging.LoggingFeature;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Our sample Application class.
+ */
 public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
 
     // Created using this as a reference: https://www.dropwizard.io/1.3.13/docs/getting-started.html
@@ -32,23 +35,39 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
     // TODO: code static analysis tools (checkstyle, etc.)
     // TODO: build static analysis tools (dependency version checking, etc.)
 
-
-    public static void main(String[] args) throws Exception {
+    /**
+     * Main method for the Application.
+     * @param args - Application's arguments
+     * @throws Exception - Throws Exception from the Application.
+     */
+    public static void main(final String[] args) throws Exception {
         new HelloWorldApplication().run(args);
     }
 
+    /**
+     * @return Name of the app.
+     */
     @Override
     public String getName() {
         return "hello-world";
     }
 
+    /**
+     * Initialize the app.
+     * @param bootstrap - DropWizard's bootstrap class.
+     */
     @Override
-    public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
+    public void initialize(final Bootstrap<HelloWorldConfiguration> bootstrap) {
         // nothing yet
     }
 
+    /**
+     * Configures the app with resources, healthchecks, logging, etc.
+     * @param configuration - config from hello-world.yml
+     * @param environment - Dropwizard's environment
+     */
     @Override
-    public void run(HelloWorldConfiguration configuration, Environment environment) throws Exception {
+    public void run(final HelloWorldConfiguration configuration, final Environment environment) throws Exception {
 
         // TODO: use DI to bind and register application specific resources
         final HelloWorldResource resource = new HelloWorldResource(

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,15 @@
 ### Getting Started
 
 [A few useful tips on how to get the tools setup.](GETTING_STARTED.md) 
+
+### Static Analysis Tools
+
+#### CheckStyle
+
+- Install CheckStyle in IntelliJ:
+  - In IntelliJ, go to ``` File | Settings | Plugins ```.
+  - Search for `CheckStyle` and install it.
+  - Restart IntelliJ. 
+
+- CheckStyle is executed via `maven-checkstyle-plugin` in Maven's `validate` phase.
+  - CheckStyle can be run via `mvn checkstyle:check` command.  

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,39 @@
     <version>1.0-SNAPSHOT</version>
     <name>gpnk-monkey-aggregator</name>
 
+    <properties>
+        <version.checkstyle>3.1.0</version.checkstyle>
+    </properties>
+
     <modules>
         <module>GoogleWagonTest</module>
         <module>HelloWorldService</module>
     </modules>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${version.checkstyle}</version>
+                <configuration>
+                    <configLocation>static-analysis/gpnk-checkstyle.xml</configLocation>
+                    <failsOnError>true</failsOnError>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <excludes>**/models/**</excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>verify-style</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <extensions>
             <extension>
                 <groupId>com.gkatzioura.maven.cloud</groupId>

--- a/static-analysis/gpnk-checkstyle.xml
+++ b/static-analysis/gpnk-checkstyle.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+
+  This config is obtained from:
+  https://github.com/checkstyle/checkstyle/blob/6bab0788365ba9afb713e14d9f6263f1f60b7aa2/src/main/resources/sun_checks.xml
+  and modified for GPNK.
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+
+    - the Sun Code Conventions at https://www.oracle.com/technetwork/java/codeconvtoc-136057.html
+
+    - the Javadoc guidelines at
+      https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html
+
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+  <!-- Configure a checker to handle files with the UTF-8 charset -->
+  <property name="charset" value="UTF-8"/>
+  <!-- Do not stop on Exception, print it as a violation -->
+  <property name="haltOnException" value="false"/>
+  <!-- File types a checker should handle -->
+  <property name="fileExtensions" value="java, xml, properties"/>
+
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <!-- Checks whether files end with a new line.                        -->
+  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+  <module name="NewlineAtEndOfFile"/>
+
+  <!-- Checks that property files contain the same keys.         -->
+  <!-- See https://checkstyle.org/config_misc.html#Translation -->
+  <module name="Translation"/>
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See https://checkstyle.org/config_sizes.html -->
+  <module name="FileLength"/>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See https://checkstyle.org/config_whitespace.html -->
+  <module name="FileTabCharacter"/>
+
+  <!-- Miscellaneous other checks.                   -->
+  <!-- See https://checkstyle.org/config_misc.html -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+
+  <module name="TreeWalker">
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See https://checkstyle.org/config_javadoc.html -->
+    <!-- Need CheckStyle 8.23 for this check, Maven plugin currently on CheckStyle 8.19  -->
+    <!--    <module name="InvalidJavadocPosition"/>-->
+    <module name="JavadocMethod"/>
+    <module name="JavadocType"/>
+    <module name="JavadocStyle"/>
+    <!-- Need CheckStyle 8.23 for this check, Maven plugin currently on CheckStyle 8.19  -->
+    <!--    <module name="MissingJavadocMethod"/>-->
+
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See https://checkstyle.org/config_naming.html -->
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+
+    <!-- Checks for imports                              -->
+    <!-- See https://checkstyle.org/config_import.html -->
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="false"/>
+    </module>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <module name="LineLength">
+      <!-- Well, Greg, I think this is quite generous :) -->
+      <property name="max" value="150"/>
+    </module>
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <module name="EmptyForIteratorPad"/>
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+
+    <!-- Modifier Checks                                    -->
+    <!-- See https://checkstyle.org/config_modifiers.html -->
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See https://checkstyle.org/config_blocks.html -->
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock"/>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+
+    <!-- Checks for common coding problems               -->
+    <!-- See https://checkstyle.org/config_coding.html -->
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <!-- MagicNumber makes sure all numbers within the code are defined as constants  -->
+    <!-- I think we can skip the MagicNumber? -->
+    <!--    <module name="MagicNumber"/>-->
+    <module name="MissingSwitchDefault"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+
+    <!-- Checks for class design                         -->
+    <!-- See https://checkstyle.org/config_design.html -->
+    <module name="DesignForExtension"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters"/>
+    <module name="UpperEll"/>
+
+  </module>
+
+</module>


### PR DESCRIPTION
So, here's the necessary evil of CheckStyle (and I don't even have Phil to blame for it...).
This PR has the following changes:
- Established parent-child relationship between aggregator and module-level poms. Needed to run `maven-checkstyle-plugin` configured in the aggregator pom in the modules.
- Added CheckStyle config file with CheckStyle for Sun's Style. I've removed a few of the proposed rules as unneeded. I think we can be refining the set of useful CheckStyle rules as we go.
- Adjusted the current code to comply with the introduced CheckStyle rules.
- Configured CheckStyle to exclude classes with `models` name in their package in order to avoid checks on POJOs. To exclude the HelloWorldConfiguration from CheckStyle, I've moved it to the `com.gpnk.models` package.
- Added instructions on installing CheckStyle in IntelliJ.

Note: There is a version discrepancy between CheckStyle plugin (version 8.23) in IntelliJ and `maven-checkstyle-plugin` (version 8.19), so some checks are behaving slightly inconsistently. I don't see this as a problem.