### PR TITLE
Added Support for TypeSafe Config

### DIFF
--- a/HelloWorldService/pom.xml
+++ b/HelloWorldService/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -35,6 +35,21 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
 
   </dependencies>

--- a/HelloWorldService/src/main/java/com/gpnk/config/ConfigUtil.java
+++ b/HelloWorldService/src/main/java/com/gpnk/config/ConfigUtil.java
@@ -1,0 +1,104 @@
+package com.gpnk.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Utility class to load HOCON TypeSafe configs. Loads environment-specific values
+ * for the current environment. Environment is defined by a property called {@code env} which defaults to "dev".
+ * The value for {@code env} can be specified via:
+ * - TypeSafe config file. Note that the included {@code reference.conf} file sets the {@code env}
+ *   to {@code dev}.
+ * - Passed as a VM option to Java, for example '-Denv=staging'.
+ * - Defined as an environment variable ENV on the current system, for example 'export ENV=staging'.
+ *   This option is enabled via environment variable override for {@code env} in reference.conf file.
+ *
+ *   <p>ConfigUtil.load() method loads environment-specific values from application.conf with fallback to reference.conf.
+ *
+ *   <p>ConfigUtil.load(String configName) loads environment-specific values from {@code configName} with fallback to
+ *   application.conf with fallback to reference.conf.
+ *
+ *   <p>ConfigUtil supports an {@code override} block which overrides values in any environment.
+ *
+ *   <p>For example:
+ *   {
+ *     flower: daisy
+ *     herb: basil
+ *     veg: tomato
+ *     berry: blackberry
+ *     dev {
+ *     }
+ *     staging {
+ *       flower: pansy
+ *       herb: dill
+ *     }
+ *     overrides {
+ *       herb: oregano
+ *       berry: ${?BERRY}
+ *     }
+ *   }
+ *
+ *   <p>For the above config:
+ *   In dev:
+ *      flower = daisy
+ *      herb = oregano
+ *      veg = tomato
+ *      berry = value of the BERRY environment variable if it is set, "blackberry" otherwise
+ *   In staging:
+ *      flower = pansy
+ *      herb = oregano
+ *      veg = tomato
+ *      berry = value of the BERRY environment variable if it is set, "blackberry" otherwise
+ */
+public final class ConfigUtil {
+
+    public static final String ENV = "env";
+    public static final String OVERRIDES = "overrides";
+
+    /**
+     * Making constructor private to prevent other classes from instantiating this "utility" class.
+     */
+    private ConfigUtil() {
+    }
+
+    /**
+     * @param configName The name of the config file to load first, for example, helloworld-reference.conf.
+     * @return Config with environment-specific values and overrides from {@code configName} with fallback to
+     *      application.conf with fallback to reference.conf.
+     */
+    public static Config load(String configName) {
+        Config fullConfig = ConfigFactory.load(configName).withFallback(ConfigFactory.load());
+        return load(fullConfig);
+    }
+
+    /**
+     * @return Config with environment-specific values and overrides from application.conf with fallback to
+     *      reference.conf.
+     */
+    public static Config load() {
+        return load(ConfigFactory.load());
+    }
+
+    /**
+     * @param fullConfig Full configuration object.
+     * @return Config with with environment-specific values and overrides from {@code fullConfig}.
+     */
+    @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
+    public static Config load(Config fullConfig) {
+        Config currentConfig = fullConfig;
+        // which environment are we in?
+        String currentEnv = fullConfig.getString(ENV);
+        // use values for our current environment where specified
+        if (fullConfig.hasPath(currentEnv)) {
+            currentConfig = fullConfig.getConfig(currentEnv).withFallback(fullConfig);
+        }
+
+        // use specified overrides
+        if (fullConfig.hasPath(OVERRIDES)) {
+            currentConfig = fullConfig.getConfig(OVERRIDES).withFallback(currentConfig);
+        }
+
+        return currentConfig;
+    }
+
+}

--- a/HelloWorldService/src/main/java/com/gpnk/config/HelloWorldProperties.java
+++ b/HelloWorldService/src/main/java/com/gpnk/config/HelloWorldProperties.java
@@ -1,0 +1,29 @@
+package com.gpnk.config;
+
+import com.typesafe.config.Config;
+import lombok.Getter;
+
+/**
+ * Configuration properties for HelloWorld which are loaded from application.conf.
+ */
+public class HelloWorldProperties {
+
+    @Getter
+    private String defaultName;
+    @Getter
+    private String nameOnlyTemplate;
+    @Getter
+    private String weatherTemplate;
+
+    /**
+     * Loads properties from application.conf.
+     */
+    public HelloWorldProperties() {
+        Config config = ConfigUtil.load();
+        Config hwConfig = config.getConfig("helloworld");
+
+        this.defaultName = hwConfig.getString("defaultName");
+        this.nameOnlyTemplate = hwConfig.getString("nameOnlyTemplate");
+        this.weatherTemplate = hwConfig.getString("weatherTemplate");
+    }
+}

--- a/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldModule.java
+++ b/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldModule.java
@@ -1,6 +1,7 @@
 package com.gpnk.helloworld;
 
 import com.gpnk.common.GPNKModule;
+import com.gpnk.config.HelloWorldProperties;
 import com.gpnk.persistence.FakeLocationDAO;
 import com.gpnk.persistence.FakeUserDAO;
 import com.gpnk.persistence.LocationDAO;
@@ -15,9 +16,14 @@ public class HelloWorldModule extends GPNKModule {
 
     @Override
     protected void config() {
-        bind(String.class).annotatedWith(Names.named("nameOnlyTemplate")).toInstance("Howdy, %s!");
-        bind(String.class).annotatedWith(Names.named("weatherTemplate")).toInstance("Hello %s, the weather is %s!");
-        bind(String.class).annotatedWith(Names.named("defaultName")).toInstance("Friend");
+        HelloWorldProperties config = new HelloWorldProperties();
+
+        // this demonstrates @Named injection
+        // if it were not for purposes of demonstration, Nadya would have preferred to inject the HelloWorldProperties
+        // object into the constructor of the HelloWorldResource class to preserve encapsulation.
+        bind(String.class).annotatedWith(Names.named("nameOnlyTemplate")).toInstance(config.getNameOnlyTemplate());
+        bind(String.class).annotatedWith(Names.named("weatherTemplate")).toInstance(config.getWeatherTemplate());
+        bind(String.class).annotatedWith(Names.named("defaultName")).toInstance(config.getDefaultName());
 
         bind(UserDAO.class).to(FakeUserDAO.class);
         bind(LocationDAO.class).to(FakeLocationDAO.class);

--- a/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
+++ b/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
@@ -91,7 +91,6 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
         // default modules
         modules.add(new CommonModule());
         modules.add(new SangriaSlf4jModule());
-
         // configured modules
         List<String> moduleClassNames = configuration.getModules();
         moduleClassNames.forEach(moduleName -> {

--- a/HelloWorldService/src/main/resources/application.conf
+++ b/HelloWorldService/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+helloworld {
+  defaultName: "Friend"
+  nameOnlyTemplate: "Howdy, %s!"
+  weatherTemplate: "Hello %s, the weather is %s!"
+}

--- a/HelloWorldService/src/main/resources/reference.conf
+++ b/HelloWorldService/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+# default to dev environment
+env: "dev"
+env: ${?ENV}

--- a/HelloWorldService/src/test/java/com/gpnk/config/ConfigUtilTest.java
+++ b/HelloWorldService/src/test/java/com/gpnk/config/ConfigUtilTest.java
@@ -1,0 +1,52 @@
+package com.gpnk.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for loading TypeSafe configs in ConfigUtil class.
+ */
+public class ConfigUtilTest {
+
+    @Test
+    public void testLoad() {
+        Config config = ConfigUtil.load();
+        assertThat(config.getString("env")).isEqualTo("dev");
+        assertThat(config.getString("flower")).isEqualTo("daisy");
+        assertThat(config.getString("herb")).isEqualTo("oregano");
+        assertThat(config.getString("veg")).isEqualTo("tomato");
+        assertThat(config.getString("berry")).isEqualTo("blackberry");
+    }
+
+    @Test
+    public void testLoadStagingEnv() {
+        Config config = ConfigUtil.load("staging-reference");
+        assertThat(config.getString("env")).isEqualTo("staging");
+        assertThat(config.getString("tree")).isEqualTo("apple");
+        assertThat(config.getString("flower")).isEqualTo("pansy");
+        assertThat(config.getString("herb")).isEqualTo("oregano");
+        assertThat(config.getString("veg")).isEqualTo("tomato");
+        assertThat(config.getString("berry")).isEqualTo("blackberry");
+    }
+
+    @Test
+    public void testLoadWithConfig() {
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("env", "staging");
+        Config envConfig = ConfigFactory.parseMap(envMap);
+        Config rawConfig = ConfigFactory.load().withValue("env", envConfig.getValue("env"));
+        Config config = ConfigUtil.load(rawConfig);
+        assertThat(config.getString("env")).isEqualTo("staging");
+        assertThat(config.getString("flower")).isEqualTo("pansy");
+        assertThat(config.getString("herb")).isEqualTo("oregano");
+        assertThat(config.getString("veg")).isEqualTo("tomato");
+        assertThat(config.getString("berry")).isEqualTo("blackberry");
+    }
+
+}

--- a/HelloWorldService/src/test/resources/application.conf
+++ b/HelloWorldService/src/test/resources/application.conf
@@ -1,0 +1,19 @@
+{
+  flower: daisy
+  herb: basil
+  veg: tomato
+  berry: blackberry
+
+  dev {
+  }
+
+  staging {
+    flower: pansy
+    herb: dill
+  }
+
+  overrides {
+    herb: oregano
+    berry: ${?BERRY}
+  }
+}

--- a/HelloWorldService/src/test/resources/staging-reference.conf
+++ b/HelloWorldService/src/test/resources/staging-reference.conf
@@ -1,0 +1,4 @@
+env: "staging"
+staging {
+  tree: "apple"
+}

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -36,6 +36,9 @@
     <version.lombok>1.18.8</version.lombok>
     <version.sangria>1.3</version.sangria>
     <version.junit>3.8.1</version.junit>
+    <version.typesafe>1.3.4</version.typesafe>
+    <version.testng>7.0.0</version.testng>
+    <version.assertj>3.13.2</version.assertj>
 
   </properties>
 
@@ -66,9 +69,29 @@
       </dependency>
 
       <dependency>
+        <groupId>com.typesafe</groupId>
+        <artifactId>config</artifactId>
+        <version>${version.typesafe}</version>
+      </dependency>
+
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>${version.testng}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
- Added `ConfigUtil` class as the main helper utility class for reading TypeSafe configs. 
- Configs are loaded with environment-specific values and an `override` section of the config - see `ConfigUtil` javadocs for details
- Added first unit tests for the `ConfigUtil` class :)

Note: DropWizard configuration as a TypeSafe config instead of a yml file is coming in the next PR. 