### PR TITLE
Added Codahale Metrics

### DIFF
--- a/HelloWorldService/src/main/java/com/gpnk/persistence/LocationDAOImpl.java
+++ b/HelloWorldService/src/main/java/com/gpnk/persistence/LocationDAOImpl.java
@@ -4,6 +4,7 @@ import com.gpnk.db.BaseDAO;
 import com.gpnk.generated.jooq.Tables;
 import com.gpnk.models.Location;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -30,6 +31,7 @@ public class LocationDAOImpl extends BaseDAO implements LocationDAO {
     }
 
     @Override
+    @Timed
     public Optional<Location> getLocationByZip(String zipCode) {
 
         SelectConditionStep results = getLocationByZipQuery(zipCode);

--- a/HelloWorldService/src/main/java/com/gpnk/persistence/UserDAOImpl.java
+++ b/HelloWorldService/src/main/java/com/gpnk/persistence/UserDAOImpl.java
@@ -5,6 +5,7 @@ import com.gpnk.generated.jooq.Tables;
 import com.gpnk.generated.jooq.tables.records.UsersRecord;
 import com.gpnk.models.User;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -31,6 +32,7 @@ public class UserDAOImpl extends BaseDAO implements UserDAO {
     }
 
     @Override
+    @Timed
     public Optional<User> getUserByName(String name) {
         SelectConditionStep results = getUserByNameQuery(name);
         Record userRecord = results.fetchOne();
@@ -42,6 +44,7 @@ public class UserDAOImpl extends BaseDAO implements UserDAO {
     }
 
     @Override
+    @Timed
     public void createUser(User user) {
         if (userExistsByName(user.getName())) {
             throw new UserAlreadyExistsException("User " + user.getName() + " already exists");

--- a/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
+++ b/HelloWorldService/src/main/java/com/gpnk/server/HelloWorldApplication.java
@@ -3,6 +3,7 @@ package com.gpnk.server;
 import com.gpnk.common.ApplicationStartupHook;
 import com.gpnk.common.CommonModule;
 import com.gpnk.common.HealthCheckable;
+import com.gpnk.common.MetricsModule;
 import com.gpnk.common.Resource;
 import com.gpnk.models.HelloWorldConfiguration;
 import com.gpnk.server.config.dropwizard.HoconConfigurationFactoryFactory;
@@ -79,6 +80,9 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
         // default modules
         modules.add(new CommonModule());
         modules.add(new SangriaSlf4jModule());
+        //configure metrics implementation with DropWizard's metric registry
+        modules.add(new MetricsModule(environment.metrics()));
+
         // configured modules
         List<String> moduleClassNames = configuration.getModules();
         moduleClassNames.forEach(moduleName -> {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>dropwizard-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.palominolabs.metrics</groupId>
+      <artifactId>metrics-guice</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/common/src/main/java/com/gpnk/common/MetricsModule.java
+++ b/common/src/main/java/com/gpnk/common/MetricsModule.java
@@ -1,0 +1,29 @@
+package com.gpnk.common;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
+import com.palominolabs.metrics.guice.MetricsInstrumentationModule;
+
+/**
+ * Enables Guice Codahale Metric annotation implementation (https://github.com/palominolabs/metrics-guice).
+ * Configures it with the given metric registry.
+ */
+public class MetricsModule extends AbstractModule {
+
+    private final MetricRegistry metricRegistry;
+
+    /**
+     * The {@code metricRegistry} to use in Guice metrics.
+     * @param metricRegistry - metric registry to use in Guice metrics.
+     */
+    public MetricsModule(final MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    protected void configure() {
+        // enable Guice Codahale Metrics with the given metric registry
+        install(MetricsInstrumentationModule.builder().withMetricRegistry(metricRegistry).build());
+    }
+
+}

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -47,6 +47,7 @@
     <version.postgresql>42.2.8</version.postgresql>
     <version.flyway>6.0.8</version.flyway>
     <version.jooq>3.12.3</version.jooq>
+    <version.metrics-guice>3.2.2</version.metrics-guice>
 
   </properties>
 
@@ -128,6 +129,22 @@
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
         <version>${version.jooq}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.palominolabs.metrics</groupId>
+        <artifactId>metrics-guice</artifactId>
+        <version>${version.metrics-guice}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/static-analysis/src/main/resources/gpnk-checkstyle.xml
+++ b/static-analysis/src/main/resources/gpnk-checkstyle.xml
@@ -66,7 +66,10 @@
 
   <!-- Miscellaneous other checks.                   -->
   <!-- See https://checkstyle.org/config_misc.html -->
+
+  <!-- https://checkstyle.org/config_regexp.html#RegexpSingleline -->
   <module name="RegexpSingleline">
+    <!-- \s matches whitespace character, $ matches end of line. -->
     <property name="format" value="\s+$"/>
     <property name="minimum" value="0"/>
     <property name="maximum" value="0"/>


### PR DESCRIPTION
- Enabled metrics collection via DropWizard's built-in Codahale metrics: https://metrics.dropwizard.io/4.0.0/getting-started.html
- Added `@Timed` annotation to the DAO methods.
- Out of the box, DropWizard supports Metric annotation on `Resource` classes only (see https://www.aytech.ca/blog/measuring-performance-dropwizard-application/). In order for the metric annotation to work on any other class in the application, one needs to supply an implementation. The PR uses aspect-oriented Guice metrics implementation: https://github.com/palominolabs/metrics-guice
- The metrics of the running application can be viewed at: http://localhost:8080/admin/metrics
- Graphite server appears to be a popular platform for metric monitoring: http://graphiteapp.org/#overview. DropWizard's metric package includes a Graphite reporter: https://metrics.dropwizard.io/4.0.0/manual/graphite.html#manual-graphite
