### PR TITLE
Register Admin Resources on Jersey's Admin Port

### DIFF
--- a/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldModule.java
+++ b/HelloWorldService/src/main/java/com/gpnk/helloworld/HelloWorldModule.java
@@ -32,5 +32,7 @@ public class HelloWorldModule extends GPNKModule {
         bindHealthCheckable(LocationDAOImpl.class);
 
         bindResource(HelloWorldResource.class);
+
+        bindAdminResource(SampleAdminResource.class);
     }
 }

--- a/HelloWorldService/src/main/java/com/gpnk/helloworld/SampleAdminResource.java
+++ b/HelloWorldService/src/main/java/com/gpnk/helloworld/SampleAdminResource.java
@@ -1,0 +1,26 @@
+package com.gpnk.helloworld;
+
+import com.gpnk.common.AdminResource;
+
+import com.codahale.metrics.annotation.Timed;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/sample")
+@Produces(MediaType.APPLICATION_JSON)
+public class SampleAdminResource implements AdminResource {
+
+    /**
+     * Sample Admin Resource GET endpoint.
+     * @return - A JSON hello response.
+     */
+    @GET
+    @Timed
+    public String sayHello() {
+        return "{ \"msg\": \"Hello, there! I am a custom admin endpoint.\"}";
+    }
+
+}

--- a/static-analysis/src/main/resources/pmd-rulesets.xml
+++ b/static-analysis/src/main/resources/pmd-rulesets.xml
@@ -55,6 +55,7 @@
     <exclude name="SignatureDeclareThrowsException"/>
     <exclude name="AvoidCatchingGenericException"/>
     <exclude name="AvoidThrowingRawExceptionTypes"/>
+    <exclude name="ExcessiveImports"/>
   </rule>
 
   <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>


### PR DESCRIPTION
Registers admin resources at:
`http://localhost:8080/admin/custom/<admin-resource-path>`
where `localhost:8080` is Jersey's admin port. 

Also, excluding `ExcessiveImports` rule from PMD due to getting the following violation:
`[INFO] PMD Failure: com.gpnk.server.HelloWorldApplication:1 Rule:ExcessiveImports Priority:3 A high number of imports can indicate a high degree of coupling within an object..
`