### PR TITLE
Fix PMD warnings from the new version of PMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ In particular [this page](https://spotbugs.readthedocs.io/en/latest/bugDescripti
 Our SpotBug exclude filters (both global and class-specific) are specified in the 
 `static-analysis/src/main/resources/spotbugs-exclude.xml` file. 
  
- 
 #### PMD
 
 [PMD's website](https://pmd.github.io/latest/index.html) is a useful resource for information about this tool. 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -335,6 +335,11 @@
             </dependency>
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-apex</artifactId>
+              <version>${version.pmd}</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
               <artifactId>pmd-java</artifactId>
               <version>${version.pmd}</version>
             </dependency>

--- a/static-analysis/src/main/resources/pmd-rulesets.xml
+++ b/static-analysis/src/main/resources/pmd-rulesets.xml
@@ -56,9 +56,12 @@
     <exclude name="AvoidCatchingGenericException"/>
     <exclude name="AvoidThrowingRawExceptionTypes"/>
     <exclude name="ExcessiveImports"/>
+    <exclude name="LoosePackageCoupling"/>
   </rule>
 
-  <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
+  <!-- https://pmd.github.io/latest/pmd_rules_apex_design.html#cognitivecomplexity -->
+  <rule ref="category/apex/design.xml/CognitiveComplexity" />
+
   <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
   <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
   <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>


### PR DESCRIPTION
- Remove a duplicate `UnnecessaryModifier` rule.
- Exclude `LoosePackageCoupling` rule (https://pmd.github.io/latest/pmd_rules_java_design.html#loosepackagecoupling). I generally like this rule. However, in the new version one has to explicitly specify the packages to which this rule is to be applied, as well as the classes which can be used outside the package. This maybe a good practice for some specific package to which we wanted to control access to, but too limiting when applied to the entire project. So, excluding this rule for now.
- Add CognitiveComplexity Rule with default settings: https://pmd.github.io/latest/pmd_rules_apex_design.html#cognitivecomplexity